### PR TITLE
Fix debug enabled test and return 500 status code when debug is on

### DIFF
--- a/tests/ConfigDebugOptionTest.php
+++ b/tests/ConfigDebugOptionTest.php
@@ -2,30 +2,50 @@
 
 namespace go1\app\tests;
 
-use DomainException;
-use go1\app\App;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\HttpFoundation\Request;
 
 class ConfigDebugOptionTest extends TestCase
 {
-    public function testConfigDebugOn()
+    private static $phpServer;
+
+    /**
+     * This method is called before the first test of this test class is run.
+     */
+    public static function setUpBeforeClass()/* The :void return type declaration that should be here would cause a BC issue */
     {
-        $app = new App(['debug' => true]);
-
-        $app->get('/give-me-error', function () {
-            throw new DomainException('Some error thrown.');
-        });
-
-        try {
-            /** @var JsonResponse $response */
-            $response = $app->handle(Request::create('/give-me-error'));
-            $json = json_decode($response->getContent());
-            $this->assertEquals(500, $response->getStatusCode());
-            $this->assertEquals('Some error thrown.', $json->message);
+        self::$phpServer = proc_open('exec php -S 127.0.0.1:4455 -t tests/fixtures/error-documentroot &> /dev/null', [], $pipes = []);
+        if (self::$phpServer !== false) {
+            usleep(100 * 1000);
         }
-        catch (DomainException $e) {
+    }
+
+    /**
+     * This method is called after the last test of this test class is run.
+     */
+    public static function tearDownAfterClass()/* The :void return type declaration that should be here would cause a BC issue */
+    {
+        if (self::$phpServer !== false) {
+            proc_terminate(self::$phpServer, 9);
         }
+    }
+
+    protected function setUp()
+    {
+        $this->assertNotFalse(self::$phpServer);
+    }
+
+    public function testItReturns500DebugOnAndErrorThrowable()
+    {
+        $fd = @fopen('http://127.0.0.1:4455/type-error', 'r');
+        $this->assertFalse($fd, 'Request was expected to fail');
+        $this->assertEquals('HTTP/1.0 500 Internal Server Error', $http_response_header[0]);
+    }
+
+    public function testItReturns500DebugOnException()
+    {
+
+        $fd = @fopen('http://127.0.0.1:4455/exception', 'r');
+        $this->assertFalse($fd, 'Request was expected to fail');
+        $this->assertEquals('HTTP/1.0 500 Internal Server Error', $http_response_header[0]);
     }
 }

--- a/tests/fixtures/error-documentroot/index.php
+++ b/tests/fixtures/error-documentroot/index.php
@@ -1,0 +1,11 @@
+<?php
+
+use go1\app\App;
+
+return call_user_func(function () {
+    require_once __DIR__ . '/../../../vendor/autoload.php';
+
+    $app = new App(require '../error-routes.config.php');
+
+    return ('cli' === php_sapi_name()) ? $app : $app->run();
+});

--- a/tests/fixtures/error-routes.config.php
+++ b/tests/fixtures/error-routes.config.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'debug'  => true,
+    'routes' => [
+        ['GET', '/type-error', function () {
+            $typedFn = function(int $dummy) {};
+            $typedFn(null);
+        }],
+        ['GET', '/exception', function () {
+            throw new \Exception('oopsie');
+        }],
+    ],
+];


### PR DESCRIPTION
This fixes microservices returning a 200 OK status code when debug is on and there's an uncaught exception.