### PR TITLE
Don't override _DOCKER_BAR to BAR if BAR already exist

### DIFF
--- a/App.php
+++ b/App.php
@@ -31,7 +31,7 @@ class App extends Application
     {
         // Remove _DOCKER_  prefix from env variables.
         foreach ($_ENV as $k => &$v) {
-            if (0 === strpos($k, '_DOCKER_')) {
+            if (0 === strpos($k, '_DOCKER_') && !isset($_ENV[substr($k, 8)])) {
                 putenv(substr($k, 8) . '=' . $v);
                 $_ENV[substr($k, 8)] = $v;
             }

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -36,4 +36,12 @@ class AppTest extends TestCase
         $app = new App(__DIR__ . '/fixtures/demo-app.config.php');
         $this->assertEquals('bar', $app['foo']);
     }
+
+    public function testConfigPathDuplicateApp()
+    {
+        $_ENV['_DOCKER_BAR'] = 'bar';
+        $_ENV['BAR'] = 'bar1';
+        $app = new App(__DIR__ . '/fixtures/demo-app.config.php');
+        $this->assertEquals('bar1', $app['bar']);
+    }
 }

--- a/tests/fixtures/demo-app.config.php
+++ b/tests/fixtures/demo-app.config.php
@@ -2,4 +2,5 @@
 
 return [
     'foo' => $_ENV['FOO'] ?? null,
+    'bar' => $_ENV['BAR'] ?? null,
 ];


### PR DESCRIPTION
Pros:
When we already provision env BAR into container. The value for that env shouldn't override with the value of _DOCKER_BAR (We may provision this env with the empty value, or the old value from GitLab)