### PR TITLE
GO1P-21152

### DIFF
--- a/App.php
+++ b/App.php
@@ -135,16 +135,16 @@ class App extends Application
         /** @var LoggerInterface $logger */
         $logger = $this['logger'];
 
-        if ($e instanceof MethodNotAllowedHttpException) {
-            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_METHOD_NOT_ALLOWED);
-        }
-
         if ($this['debug']) {
             http_response_code(500);
             throw $e;
         }
 
         $logger->error($e->getMessage());
+
+        if ($e instanceof MethodNotAllowedHttpException) {
+            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
 
         if ($e instanceof DBALException) {
             $message = $this['debug'] ? $e->getMessage() : 'Database error #' . $e->getCode();

--- a/App.php
+++ b/App.php
@@ -13,6 +13,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
+use Symfony\Component\HttpKernel\Exception\MethodNotAllowedHttpException;
 
 class App extends Application
 {
@@ -133,6 +134,10 @@ class App extends Application
     {
         /** @var LoggerInterface $logger */
         $logger = $this['logger'];
+
+        if ($e instanceof MethodNotAllowedHttpException) {
+            return new JsonResponse(['message' => $e->getMessage()], Response::HTTP_METHOD_NOT_ALLOWED);
+        }
 
         if ($this['debug']) {
             http_response_code(500);


### PR DESCRIPTION
Respond with code "405" instead of "500" when Method is not allowed. Solving https://go1web.atlassian.net/browse/GO1P-21152

In order to achieve a more consistent behavior across the microservices, I propose to handle all "MethodNotAllowedHttpException" globally instead of in each microservice individually.