### PR TITLE
Added user-defined header into $client

### DIFF
--- a/providers/CoreServiceProvider.php
+++ b/providers/CoreServiceProvider.php
@@ -288,6 +288,9 @@ class CoreServiceProvider implements ServiceProviderInterface
             foreach ($_SERVER as $name => $value) {
                 if (substr($name, 0, 7) == 'HTTP_X_') {
                     $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($name, $value) {
+                        // Add header to request, follow by section Fielding of RFC 2616
+                        // Example from `$_SERVER['HTTP_X_REQUEST_ID']` we will have the header name `X-Request-Id`
+                        // @see: http://php.net/manual/en/function.getallheaders.php#84262
                         return $request->withHeader(str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5))))), $value);
                     }));
                 }

--- a/providers/CoreServiceProvider.php
+++ b/providers/CoreServiceProvider.php
@@ -264,15 +264,6 @@ class CoreServiceProvider implements ServiceProviderInterface
 
     private function registerClientService(Container $c)
     {
-        $c['client.middleware.map-request'] = function () {
-            return Middleware::mapRequest(function (RequestInterface $req) {
-                if (isset($_SERVER['HTTP_X_REQUEST_ID'])) {
-                    return $req->withHeader('X-Request-ID', $_SERVER['HTTP_X_REQUEST_ID']);
-                }
-
-                return $req->withHeader('X-Request-ID', 'N/A');
-            });
-        };
 
         $c['client.middleware.profiler'] = function () {
             return new GuzzleHistory(new Stopwatch);
@@ -283,7 +274,6 @@ class CoreServiceProvider implements ServiceProviderInterface
             $options = $c['clientOptions'] + ['User-Agent' => 'GO1 ' . $c::NAME . '/' . $c::VERSION];
 
             $stack = HandlerStack::create(new CurlHandler);
-//            $stack->push($c['client.middleware.map-request']);
             // Add user-defined header, mentioned in a.o. section 5 of RFC 2047. (https://tools.ietf.org/html/rfc2047#section-5)
             foreach ($_SERVER as $name => $value) {
                 if (substr($name, 0, 7) == 'HTTP_X_') {

--- a/providers/CoreServiceProvider.php
+++ b/providers/CoreServiceProvider.php
@@ -285,10 +285,8 @@ class CoreServiceProvider implements ServiceProviderInterface
             $stack = HandlerStack::create(new CurlHandler);
 //            $stack->push($c['client.middleware.map-request']);
             // Add user-defined header, mentioned in a.o. section 5 of RFC 2047. (https://tools.ietf.org/html/rfc2047#section-5)
-            foreach ($_SERVER as $name => $value)
-            {
-                if (substr($name, 0, 7) == 'HTTP_X_')
-                {
+            foreach ($_SERVER as $name => $value) {
+                if (substr($name, 0, 7) == 'HTTP_X_') {
                     $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($name, $value) {
                         return $request->withHeader(str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5))))), $value);
                     }));

--- a/tests/ClientServiceTest.php
+++ b/tests/ClientServiceTest.php
@@ -48,7 +48,6 @@ class ClientServiceTest extends TestCase
         ]);
 
         $stack = new HandlerStack($h);
-//        $stack->push($app['client.middleware.map-request']);
         foreach ($_SERVER as $name => $value) {
             if (substr($name, 0, 7) == 'HTTP_X_') {
                 $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($name, $value) {

--- a/tests/ClientServiceTest.php
+++ b/tests/ClientServiceTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Middleware;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\RequestInterface;
 
@@ -32,18 +33,29 @@ class ClientServiceTest extends TestCase
     {
         $app = new App(['clientOptions' => []]);
         $_SERVER['HTTP_X_REQUEST_ID'] = 'Foo-Bar';
+        $_SERVER['HTTP_X_CUSTOM'] = 'Foo-Foo';
+        $_SERVER['HTTP_X_TRACE'] = 'Bar-Bar';
 
         // @see https://github.com/guzzle/guzzle/blob/master/tests/MiddlewareTest.php#L144
         $h = new MockHandler([
             function (RequestInterface $request, array $options) {
-                $this->assertEquals('Foo-Bar', $request->getHeaderLine('X-Request-ID'));
+                $this->assertEquals('Foo-Bar', $request->getHeaderLine('X-Request-Id'));
+                $this->assertEquals('Foo-Foo', $request->getHeaderLine('X-Custom'));
+                $this->assertEquals('Bar-Bar', $request->getHeaderLine('X-Trace'));
 
                 return new Response(200);
             },
         ]);
 
         $stack = new HandlerStack($h);
-        $stack->push($app['client.middleware.map-request']);
+//        $stack->push($app['client.middleware.map-request']);
+        foreach ($_SERVER as $name => $value) {
+            if (substr($name, 0, 7) == 'HTTP_X_') {
+                $stack->push(Middleware::mapRequest(function (RequestInterface $request) use ($name, $value) {
+                    return $request->withHeader(str_replace(' ', '-', ucwords(strtolower(str_replace('_', ' ', substr($name, 5))))), $value);
+                }));
+            }
+        }
 
         $comp = $stack->resolve();
         $p = $comp(new Request('PUT', 'http://www.google.com'), []);


### PR DESCRIPTION
Follow by [section 5 of RFC 2047](https://tools.ietf.org/html/rfc2047#section-5).

I want to implements [opentracing](https://opentracing.io/specification/).

The implements is not powerful at the moment, but we should have a good start if service can forward the header before call into other service, so we can have the dependences of service.

P/S: This also fix a naming for our header. Before we use `X-Request-ID`, but the correct header name should be `X-Request-Id`