### PR TITLE
Downgrade Symfony serviice contracts to 1.1 due to bad support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "go1/jwt-middleware": "^0.4",
     "silex/silex":        "^v2.3.0",
     "symfony/stopwatch":  "^3.2",
-    "symfony/service-contracts": "^2.0"
+    "symfony/service-contracts": "^1.1"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^6.2",


### PR DESCRIPTION
Seems that 2.0 tag is too new and not well supported by other packages yet.