### PR TITLE
Fix httpexception 500

### DIFF
--- a/domain/profiler/DatabaseProfilerStorage.php
+++ b/domain/profiler/DatabaseProfilerStorage.php
@@ -47,7 +47,7 @@ class DatabaseProfilerStorage implements ProfilerStorageInterface
         );
     }
 
-    public function find($ip, $url, $limit, $method, $start = null, $end = null)
+    public function find($ip, $url, $limit, $method, $start = null, $end = null) : array
     {
         $q = $this
             ->db
@@ -73,7 +73,7 @@ class DatabaseProfilerStorage implements ProfilerStorageInterface
         return $rows ?? [];
     }
 
-    public function write(Profile $profile)
+    public function write(Profile $profile) : bool
     {
         $fields = [
             'token'       => $profile->getToken(),
@@ -94,7 +94,7 @@ class DatabaseProfilerStorage implements ProfilerStorageInterface
             ),
         ];
 
-        $this->db->insert('profiler_items', $fields);
+        return $this->db->insert('profiler_items', $fields) > 0;
     }
 
     public function purge()
@@ -102,7 +102,7 @@ class DatabaseProfilerStorage implements ProfilerStorageInterface
         $this->db->delete('profiler_items', []);
     }
 
-    public function read($token)
+    public function read($token) : ?Profile
     {
         $items = $this->readMultiple([$token]);
 

--- a/tests/CoreMiddlewareTest.php
+++ b/tests/CoreMiddlewareTest.php
@@ -1,0 +1,39 @@
+<?php
+namespace go1\app\tests;
+
+use go1\app\providers\CoreMiddlewareProvider;
+use PHPUnit\Framework\TestCase;
+use Silex\Application;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+class CoreMiddlewareTest extends TestCase
+{
+    public function testHttpException()
+    {
+        $testSubject = new CoreMiddlewareProvider();
+
+        $appMock = $this->createMock(Application::class);
+        $appMock->method('offsetExists')->willReturn(false);
+
+        $appMock
+            ->method('error')
+            ->withConsecutive([$this->callback(function ($val) {
+                    $notFoundException = new NotFoundHttpException('foo');
+                    $response = $val($notFoundException);
+                    $this->assertInstanceOf(JsonResponse::class, $response);
+                    $this->assertEquals($notFoundException->getStatusCode(), $response->getStatusCode());
+                    return true;
+                })],
+                [$this->callback(function ($val) {
+                    $e = new \Exception('foo');
+                    $response = $val($e);
+                    $this->assertInstanceOf(JsonResponse::class, $response);
+                    $this->assertEquals(500, $response->getStatusCode());
+                    return true;
+                })]
+            );
+
+        $testSubject->boot($appMock);
+    }
+}


### PR DESCRIPTION
In production exceptions are caught by a different execution path, and instances of HttpException -which is normal behaviour in Silex- are always returning a 500 error for bad routes and methods.