### PR TITLE
Support datadog for go1/app

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
     "go1/jwt-middleware": "^0.4",
     "silex/silex":        "^v2.3.0",
     "symfony/stopwatch":  "^3.2",
-    "symfony/service-contracts": "^1.1"
+    "symfony/service-contracts": "^1.1",
+    "datadog/dd-trace": "^0.39.1"
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^6.2",

--- a/providers/CoreServiceProvider.php
+++ b/providers/CoreServiceProvider.php
@@ -49,6 +49,8 @@ use Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\Stopwatch\Stopwatch;
+use DDTrace\Bootstrap;
+use DDTrace\Integrations\IntegrationsLoader;
 
 class CoreServiceProvider implements ServiceProviderInterface
 {
@@ -66,6 +68,7 @@ class CoreServiceProvider implements ServiceProviderInterface
         $this->registerLogServices($c);
         $c->offsetExists('clientOptions') && $this->registerClientService($c);
         $this->registerProfilerServices($c);
+        $this->registerTracingService();
 
         $c['middleware.jwt'] = function () { return new JwtMiddleware; };
         $c['middleware.core'] = function () { return new CoreMiddlewareProvider; };
@@ -284,5 +287,13 @@ class CoreServiceProvider implements ServiceProviderInterface
 
             return new Client($options);
         };
+    }
+
+    private function registerTracingService()
+    {
+        if (!empty(getenv('DD_AGENT_HOST')) && extension_loaded('ddtrace')) {
+            Bootstrap::tracerOnce();
+            IntegrationsLoader::load();
+        }
     }
 }


### PR DESCRIPTION
Datadog haven't supported EOL silex, but its have supported for core libraries like GuzzleHttp, Doctrine...

For unknown reason, the autoloader from dd-trace php extension didn't work on silex, so I just manual Bootstrap and active datadog integration when extension ddtrace is loaded and we have valid env DD_AGENT_HOST

This is the example tracing working on go1/app:
GuzzleHttp:
<img width="673" alt="Screen Shot 2020-02-11 at 11 22 02 AM" src="https://user-images.githubusercontent.com/128535/74204898-cb82cc00-4cc0-11ea-8e73-4f2357fee88f.png">
Doctrine:
<img width="1342" alt="Screen Shot 2020-02-11 at 11 22 54 AM" src="https://user-images.githubusercontent.com/128535/74204934-e8b79a80-4cc0-11ea-8e12-22f5447dc5d4.png">
