### PR TITLE
Force client to use ipv4 within stack

### DIFF
--- a/providers/CoreServiceProvider.php
+++ b/providers/CoreServiceProvider.php
@@ -311,6 +311,12 @@ class CoreServiceProvider implements ServiceProviderInterface
                 $options['headers']['User-Agent'] = substr($_SERVER['HTTP_USER_AGENT'], 0, 256);
             }
 
+            $options['force_ip_resolve'] = 'v4';
+            # The client don't use CurlMultiHandler stack, so the curl option need to be on curl array.
+            # https://docs.guzzlephp.org/en/stable/faq.html#how-can-i-add-custom-curl-options
+            $options['curl']['CURLOPT_DNS_SHUFFLE_ADDRESSES'] = false;
+            $options['curl']['CURLOPT_DNS_USE_GLOBAL_CACHE'] = true;
+
             $stack = HandlerStack::create(new CurlHandler);
             // Add user-defined header, mentioned in a.o. section 5 of RFC 2047. (https://tools.ietf.org/html/rfc2047#section-5)
             foreach ($_SERVER as $name => $value) {


### PR DESCRIPTION
The public api (Extend from the base app) has few DNS resolve errors. It's not clear what is the reason. This PR is to make sure that the client uses IPv4 and does not use CURLOPT_DNS_SHUFFLE_ADDRESSES for other services.